### PR TITLE
Fix: Add isonet.py alternate directory to PATH in isonet2.bashrc

### DIFF
--- a/isonet2.bashrc
+++ b/isonet2.bashrc
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 ISONET_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+export PATH="$ISONET_DIR/IsoNet/bin:$PATH"
 export PATH="$ISONET_DIR/build/conda_env/bin:$PATH"
 
 if [ -x "$ISONET_DIR/isoapp-1.0.0.AppImage" ]; then


### PR DESCRIPTION
This serves as a fallback to the path of isonet.py in case the installation was performed without using the command 'bash install.sh' (giving an option to use the faster mamba to create the environment).