### PR TITLE
Feat: add mamba usage ability to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,17 @@
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 mkdir -p ${SCRIPT_DIR}/build
 
+# Checking if Mamba exists, and using that instead
+if command -v mamba &> /dev/null; then
+    CONDA_SOLVER="mamba"
+    echo "Using mamba for environment creation."
+else
+    CONDA_SOLVER="conda"
+    echo "Using conda for environment creation."
+fi
+
 # Install Conda env
-conda env create -p "${SCRIPT_DIR}/build/conda_env" -f "${SCRIPT_DIR}/isonet2_environment.yml"
+${CONDA_SOLVER} env create -p "${SCRIPT_DIR}/build/conda_env" -f "${SCRIPT_DIR}/isonet2_environment.yml"
 
 # Intall IsoNet via pip
 cd ${SCRIPT_DIR}


### PR DESCRIPTION
```shell
conda env create 
``` 
can be a slow command. Using mamba instead in the install.sh (if it is found on the path) is much faster.