### PR TITLE
Fix environment file to fix dependency issues during installation

### DIFF
--- a/isonet2_environment.yml
+++ b/isonet2_environment.yml
@@ -8,6 +8,7 @@ dependencies:
   # --- Conda Packages ---
   - python=3.10
   - pip
+  - wheel<0.46
 
   # PyTorch Core
   - pytorch==2.1.1
@@ -26,7 +27,7 @@ dependencies:
   - numpy<2.0
   - scipy
   - pandas
-  - scikit-image
+  - scikit-image=0.22.*
   - pillow
   - mrcfile
   - pyarrow


### PR DESCRIPTION
Hi, 

as described by another user in issue #23, the installation currently does not work as described in the instructions. The issue is that the newest version of `scikit-image` clashes with the older requirements for `lazy-loader` and `pillow`, which are pinned in the requirements file. 
This PR solves this issue by pinning `scikit-image` to 0.22, which is the newest version supporting the pinned version of `lazy-loader`. 

Best,
Benedikt

